### PR TITLE
bring Solution to build on Mac OS X with mono & FAKE

### DIFF
--- a/Numsense.UnitTests.CSharp/Numsense.UnitTests.CSharp.csproj
+++ b/Numsense.UnitTests.CSharp/Numsense.UnitTests.CSharp.csproj
@@ -9,8 +9,9 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>Ploeh.Numsense.UnitTests</RootNamespace>
     <AssemblyName>Ploeh.Numsense.UnitTests.CSharp</AssemblyName>
-    <TargetFrameworkVersion>v4.6</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
+    <TargetFrameworkProfile />
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
@@ -74,7 +75,9 @@
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>
-    <None Include="app.config" />
+    <None Include="app.config">
+      <SubType>Designer</SubType>
+    </None>
     <None Include="packages.config" />
   </ItemGroup>
   <ItemGroup>

--- a/Numsense.UnitTests.CSharp/app.config
+++ b/Numsense.UnitTests.CSharp/app.config
@@ -3,9 +3,12 @@
   <runtime>
     <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
       <dependentAssembly>
-        <assemblyIdentity name="FSharp.Core" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-4.4.0.0" newVersion="4.4.0.0" />
+        <assemblyIdentity name="FSharp.Core" publicKeyToken="b03f5f7f11d50a3a" culture="neutral"/>
+        <bindingRedirect oldVersion="0.0.0.0-4.4.0.0" newVersion="4.4.0.0"/>
       </dependentAssembly>
     </assemblyBinding>
   </runtime>
+  <startup>
+    <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.5"/>
+  </startup>
 </configuration>

--- a/Numsense.UnitTests.CSharp/packages.config
+++ b/Numsense.UnitTests.CSharp/packages.config
@@ -1,12 +1,11 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="FsCheck" version="2.2.4" targetFramework="net46" />
-  <package id="FsCheck.Xunit" version="2.2.4" targetFramework="net46" />
-  <package id="FSharp.Core" version="4.0.0.1" targetFramework="net46" />
-  <package id="xunit" version="2.1.0" targetFramework="net46" />
-  <package id="xunit.abstractions" version="2.0.0" targetFramework="net46" />
-  <package id="xunit.assert" version="2.1.0" targetFramework="net46" />
-  <package id="xunit.core" version="2.1.0" targetFramework="net46" />
-  <package id="xunit.extensibility.core" version="2.1.0" targetFramework="net46" />
-  <package id="xunit.extensibility.execution" version="2.1.0" targetFramework="net46" />
+  <package id="FsCheck" version="2.2.4" targetFramework="net45" />
+  <package id="FsCheck.Xunit" version="2.2.4" targetFramework="net45" />
+  <package id="FSharp.Core" version="4.0.0.1" targetFramework="net45" />
+  <package id="xunit" version="2.1.0" targetFramework="net45" />
+  <package id="xunit.abstractions" version="2.0.0" targetFramework="net45" />
+  <package id="xunit.core" version="2.1.0" targetFramework="net45" />
+  <package id="xunit.extensibility.core" version="2.1.0" targetFramework="net45" />
+  <package id="xunit.extensibility.execution" version="2.1.0" targetFramework="net45" />
 </packages>

--- a/Numsense.nuspec
+++ b/Numsense.nuspec
@@ -16,7 +16,7 @@
     </dependencies>
   </metadata>
   <files>
-    <file src="Numsense\bin\Release\Ploeh.Numsense.dll" target="lib\net45" />
-    <file src="Numsense\bin\Release\Ploeh.Numsense.XML" target="lib\net45" />
+    <file src="Numsense/bin/Release/Ploeh.Numsense.dll" target="lib\net45" />
+    <file src="Numsense/bin/Release/Ploeh.Numsense.XML" target="lib\net45" />
   </files>
 </package>

--- a/Numsense.sln
+++ b/Numsense.sln
@@ -9,6 +9,16 @@ Project("{F2A71F9B-5D33-465A-A702-920D77279786}") = "Numsense.UnitTests", "Numse
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Numsense.UnitTests.CSharp", "Numsense.UnitTests.CSharp\Numsense.UnitTests.CSharp.csproj", "{5FEBD8A6-3ED8-4E4F-B484-DE4CB77B6034}"
 EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{98273287-AB32-4958-B4C2-47D77A7D42F0}"
+	ProjectSection(SolutionItems) = preProject
+		Build.fsx = Build.fsx
+		build.sh = build.sh
+		CONTRIBUTING.md = CONTRIBUTING.md
+		LICENCE.txt = LICENCE.txt
+		Numsense.nuspec = Numsense.nuspec
+		README.md = README.md
+	EndProjectSection
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU

--- a/build.cmd
+++ b/build.cmd
@@ -1,0 +1,4 @@
+@echo off
+cls
+
+packages\FAKE.4.11.3\tools\FAKE.exe build.fsx %*

--- a/build.sh
+++ b/build.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+if test "$OS" = "Windows_NT"
+then
+  # use .Net
+
+  packages/FAKE.4.11.3/tools/FAKE.exe $@ --fsiargs build.fsx
+else
+  # use mono
+
+  mono packages/FAKE.4.11.3/tools/FAKE.exe $@ --fsiargs -d:MONO build.fsx
+fi


### PR DESCRIPTION
Following is done:
.) added scripts for cmd & bash build
.) downgrade Numsense.UnitTests.CSharp.csproj to .Net v4.5 - v4.6 is not yet supported in mono/xbuild
.) fixed paths in nuspec
.) add root files to Solution