### PR TITLE
Fixed Build.fsx casing to work on case sensitive environments

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -3,9 +3,9 @@ if test "$OS" = "Windows_NT"
 then
   # use .Net
 
-  packages/FAKE.4.11.3/tools/FAKE.exe $@ --fsiargs build.fsx
+  packages/FAKE.4.11.3/tools/FAKE.exe $@ --fsiargs Build.fsx
 else
   # use mono
 
-  mono packages/FAKE.4.11.3/tools/FAKE.exe $@ --fsiargs -d:MONO build.fsx
+  mono packages/FAKE.4.11.3/tools/FAKE.exe $@ --fsiargs -d:MONO Build.fsx
 fi


### PR DESCRIPTION
Systems that have case sensitive file names (i.e. Linux) won't find build.fsx. Just changing the case so all the :penguin: will be happy again :wink: